### PR TITLE
Add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "timer_heap"
 version = "0.1.1"
 authors = ["Andrew J. Stone <andrew.j.stone.1@gmail.com>"]
 description = "A binary heap based timer management system"
+repository = "https://github.com/andrewjstone/timer_heap"
 keywords = ["timer", "heap"]
 license = "Apache-2.0"
 


### PR DESCRIPTION
This will cause a link to the GitHub project to appear on crates.io and docs.rs.